### PR TITLE
add reusable Textarea component

### DIFF
--- a/src/components/WebsiteGoals.jsx
+++ b/src/components/WebsiteGoals.jsx
@@ -1,23 +1,15 @@
 import Question from '../utils/Question'
+import TextareaInput from '../utils/Textarea'
 import styled from 'styled-components'
 
 function WebsiteGoals() {
   return (<>
     <Question>What goals do you want to accomplish with your new website?</Question>
-    <Textarea></Textarea>
+    <TextareaInput placeholder='I.e.: Sell goods or services, disseminate knowledge, increase brand recognition, etc.
+'></TextareaInput>
     </>)
 }
 
-const Textarea = styled.textarea`
-width: 70%;
-height: 8rem;
-padding: 1rem;
-border-radius: 20px;
-border: none;
-margin-top: 1.5rem;
-&:focus {
-  border: 2px solid gray;
-}
-`
+
 
 export default WebsiteGoals

--- a/src/utils/Question.jsx
+++ b/src/utils/Question.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components';
 
 export default function Question({children}) {

--- a/src/utils/Textarea.jsx
+++ b/src/utils/Textarea.jsx
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+function Textarea() {
+  return (
+    <TextareaInput></TextareaInput>
+  )
+}
+
+
+const TextareaInput = styled.textarea`
+width: 70%;
+height: 8rem;
+padding: 1rem;
+border-radius: 20px;
+border: none;
+margin-top: 1.5rem;
+&:focus {
+  border: 2px solid gray;
+}
+`
+
+export default Textarea


### PR DESCRIPTION
## Summary
Fixes issue #5 

Abstract Textarea styled component and make it into a reusable one.

## Details

### Why?
The styles and functionality are the same for every component that requires a textarea, so instead of bloating the codebase with redundant repetition, it's more practical and efficient to make it into a reusable component.

### How?
I added Textarea functinal component in Utils folder. Component returns TextareaInput styled component.

## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
