### PR TITLE
replace ServicesDescription textarea with Textarea component and pass props to Textarea component

### DIFF
--- a/src/components/ServicesDescription.jsx
+++ b/src/components/ServicesDescription.jsx
@@ -1,27 +1,16 @@
 import Question from '../utils/Question'
-import styled from 'styled-components'
-
+import Textarea from '../utils/Textarea'
 
 function ServicesDescription() {
   return (<>
     <Question>What specific services does your company provide? List all that apply.</Question>
     <Textarea placeholder='I.e.: Sell goods or services, disseminate knowledge, increase brand recognition, etc.
-'></Textarea>
+' name='services-description'></Textarea>
     </>)
 }
 
 
-  const Textarea = styled.textarea`
-  width: 70%;
-  height: 8rem;
-  padding: 1rem;
-  border-radius: 20px;
-  border: none;
-  margin-top: 1.5rem;
-  &:focus {
-    border: 2px solid gray;
-  }
-`
+
 
 
 export default ServicesDescription

--- a/src/utils/Textarea.jsx
+++ b/src/utils/Textarea.jsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
-function Textarea() {
+function Textarea({placeholder, name}) {
   return (
-    <TextareaInput></TextareaInput>
+    <TextareaInput placeholder={placeholder} name={name}></TextareaInput>
   )
 }
 


### PR DESCRIPTION
## Summary
Fixes issue #7 

Replace ServicesDescription textarea styled component with Textarea component. 

Add placeholder and name props to Textarea component.

## Details

### Why?
Add placeholder and name props to Textcomponent prop so that placeholder can be rendered in UI. Without a prop, the placeholder text won't be rendered.

The name attribute will set the name of the associated data point submitted to the server when the form is submitted.


### How?
In Textarea component, destructure placeholder and name props in function argument. Set placeholder and name attributes equal to these values. Values are set wherever this component is used and are passed as strings.

## Additional Information

## Checks
- [x] Did you reference the issue? 
- [ ] Does this commit follow SRP? 
