### PR TITLE
add RadioButton component and use in BackgroundInfo

### DIFF
--- a/src/components/BackgroundInfo.jsx
+++ b/src/components/BackgroundInfo.jsx
@@ -1,35 +1,33 @@
 import React from 'react'
 import styled from 'styled-components'
 import QuestionText from '../utils/Question';
+import RadioButton from '../utils/RadioButton';
 
 function BackgroundInfo() {
   return (<>
     <QuestionText>Do you have content ready for your site?</QuestionText>
-    <SelectionContainer>
-      <Input type='radio' id='yes' value='yes' name='background-info-content'/>
-      <Label for='yes'>Yes, I have content ready.</Label>
-    </SelectionContainer>
-    
-    <SelectionContainer>
-      <Input type='radio' id='no' value='no' name='background-info-content'/>
-      <Label for='no'>Not yet. I'm still working on it.</Label>
-    </SelectionContainer>
+
+    <RadioButton id='yes-content' value='yes-content' name='background-info-content'>
+      Yes, I have content ready.
+    </RadioButton>
+  
+    <RadioButton id='no-content' value='no-content' name='background-info-content'>
+      Not yet. I'm still working on it.
+    </RadioButton>
   
     <QuestionText>Is your company legally registered?</QuestionText>
-    <SelectionContainer>
-      <Input type='radio' id='yes' value='yes' name='background-info-legally-registered'/>
-      <Label for='yes'>Yes.</Label>
-    </SelectionContainer>
-    
-    <SelectionContainer>
-      <Input type='radio' id='no' value='no' name='background-info-legally-registered'/>
-      <Label for='no'>No.</Label>
-    </SelectionContainer>
+
+    <RadioButton id='yes-registered' value='yes-registered' name='background-info-legally-registered' >
+      Yes.
+    </RadioButton>
+     
+    <RadioButton id='no-registered' value='no-registered' name='background-info-legally-registered'>
+      No.
+    </RadioButton>
    
-    <SelectionContainer>
-      <Input type='radio' id='no' value='in the process' name='background-info-legally-registered'/>
-      <Label for='no'>I'm in the process of registering it.</Label>
-    </SelectionContainer>
+    <RadioButton id='not-yet' value='not-yet' name='background-info-legally-registered'>
+      I'm in the process of registering it.
+    </RadioButton>
     </>
   )
 }

--- a/src/utils/RadioButton.jsx
+++ b/src/utils/RadioButton.jsx
@@ -1,0 +1,36 @@
+import styled from "styled-components"
+
+
+function RadioButton({id, value, name, children}) {
+  return (<>
+    <SelectionContainer>
+        <Input type='radio'  id={id} value={value}  name={name}/>
+        <Label for={id}>
+            {children}
+        </Label>
+    </SelectionContainer>
+  </>)
+}
+
+const Input = styled.input`
+  margin-right: 1rem;
+  height: 1.1rem;
+  width: 1.1rem;
+  accent-color: grey;
+`;
+
+const Label = styled.label`
+  color: white;
+`;
+
+
+
+const SelectionContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  width: 80%;
+  height: 5rem;
+`;
+
+export default RadioButton


### PR DESCRIPTION
## Summary
Fixes issue #10 

Make a reusable radio button styled component that can be used throughout the application.

## Details

### Why?
To avoid code repetition. 

### How?
Make styled RadioButton component in Utils folder. Set id, value, name, and children props on input and make label customisable by passing it children.

## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
