### PR TITLE
add backup colors for next and previous buttons' arrow icons

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -150,11 +150,18 @@ const PrevButton = styled.button`
     font-size: 1rem;
     cursor: pointer;
 
-    i {
+    @supports (background-clip: text) {
+       i {
         background: linear-gradient( to right, #FDB456, #DD7A78, #BA3D9C);
         background-clip: text;
         color: transparent;
+      }
     }
+
+    i {
+      color: #BA3D9C;
+    }
+   
      
 
  
@@ -174,7 +181,21 @@ const NextButton = styled.button`
     display: flex;
     /* justify-content: space-around; */
     align-items: center;
-    cursor: pointer;
+    cursor: pointer; 
+    
+    @supports (background-clip: text) {
+      p {
+        background: linear-gradient( to right, #FDB456, #DD7A78, #BA3D9C);
+        background-clip: text;
+        color: transparent;
+      }
+      
+      i {
+        background: linear-gradient( to right, #FDB456, #DD7A78, #BA3D9C);
+        background-clip: text;
+        color: transparent;
+      }
+    }
 
     p {
       color: #BA3D9C;
@@ -185,20 +206,13 @@ const NextButton = styled.button`
       margin-right: 1rem;
      }
 
-    @supports (background-clip: text) {
-      p {
-        background: linear-gradient( to right, #FDB456, #DD7A78, #BA3D9C);
-        /* background-clip: text; */
-        -webkit-background-clip: text;
-        color: transparent;
-      }
-    }
+     i {
+      color: #BA3D9C;
+     }
 
-    i {
-        background: linear-gradient( to right, #FDB456, #DD7A78, #BA3D9C);
-        background-clip: text;
-        color: transparent;
-    }
+  
+
+    
 `;
 
 


### PR DESCRIPTION
## Summary
Fixes issue #15 
add backup colors for next and previous buttons' arrow icons
## Details

### Why?
In Chrome, the  `background-clip: text; ` style isn't supported and so the linear gradient background icon color wasn't rendering properly. 
### How?
In the Form component, wrap icon linear gradient styles in  `@support (background-clip:text) {} ` to show linear gradient when supported. Beneath this, add a backup icon color for unsupported browsers to fall back on. 
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
