### PR TITLE
add copyright and year to footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,9 +1,26 @@
 import React from 'react'
+import styled from 'styled-components'
 
 function Footer() {
+
+  const currentYear = new Date().getFullYear();
   return (
-    <div>Footer</div>
+    <FooterContainer>
+      <Copyright>
+        Christopher Chamberlain &copy; {currentYear} 
+      </Copyright>
+    </FooterContainer>
   )
 }
+
+const FooterContainer = styled.footer`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Copyright = styled.p`
+  
+`;
 
 export default Footer


### PR DESCRIPTION
## Summary
Fixes issue #17 

## Details

### Why?
Footer needs content.
### How?
Add text content and use the .getFullYear() method on the Date() object to return the current year.
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
