### PR TITLE
position other textarea beneath other checkbox

### DIFF
--- a/src/components/ContentType.jsx
+++ b/src/components/ContentType.jsx
@@ -1,9 +1,28 @@
-import React from 'react'
+import Question from "../utils/Question"
+import Checkbox from "../utils/Checkbox"
 
 function ContentType() {
-  return (
-    <div>ContentType</div>
-  )
+  return (<>
+    <Question>What kind of content do you plan to publish on your website? Select all that apply. </Question>
+    <Checkbox id='picture' name='picture' value='picture'>
+      Pictures
+    </Checkbox>
+    <Checkbox id='video' name='video' value='video'>
+      Videos
+    </Checkbox>
+    <Checkbox id='music files' name='music files' value='music files'>
+      Music files
+    </Checkbox>
+    <Checkbox id='blog posts' name='blog posts' value='blog posts'>
+      Blog posts
+    </Checkbox>
+    <Checkbox id='product listings' name='product listings' value='product listings'>
+      Product listings
+    </Checkbox>
+    <Checkbox id='other' name='other' value='other' placeholder='Please explain.'>
+      Other
+    </Checkbox>
+  </>)
 }
 
 export default ContentType

--- a/src/utils/Checkbox.jsx
+++ b/src/utils/Checkbox.jsx
@@ -1,0 +1,44 @@
+import styled from "styled-components"
+import Textarea from "./Textarea";
+
+
+function Checkbox({id, name, value, children, placeholder}) {
+    
+    
+    return ( <>
+        <CheckboxContainer>
+            <Input type="checkbox" id={id} name={name} value={value}/>
+            <Label for={id}>
+                {children}
+            </Label>
+        </CheckboxContainer>  
+        {id === 'other' && 
+                <div className="other-text-input">
+                    <Textarea placeholder={placeholder} name={name}></Textarea>
+
+                </div>
+            }
+  </>)
+}
+
+
+const CheckboxContainer = styled.div`
+display: flex;
+align-items: center;
+justify-content: flex-start;
+width: 80%;
+height: 5rem;
+`;
+
+const Input = styled.input`
+  margin-right: 1rem;
+  height: 1.1rem;
+  width: 1.1rem;
+  accent-color: grey;
+`;
+
+const Label = styled.label`
+  color: white;
+`;
+
+export default Checkbox


### PR DESCRIPTION
## Summary
Fixes issue #11 

## Details

### Why?
As multiple form components will be using a checkbox input with identical styling, it makes sense to make and use a reusable component.
### How?
Make a checkbox component. Pass to it id, name, value, children, and placeholder props so that it can be customised.
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
