### PR TITLE
only show other textarea when 'other' checkbox is checked

### DIFF
--- a/src/utils/Checkbox.jsx
+++ b/src/utils/Checkbox.jsx
@@ -1,21 +1,25 @@
 import styled from "styled-components"
 import Textarea from "./Textarea";
+import { useState } from "react";
 
 
 function Checkbox({id, name, value, children, placeholder}) {
-    
-    
+    const [checked, setChecked] = useState(false);
+
+    const displayOtherTextareaInput = (event) => {
+      setChecked(event.target.checked)
+    } 
+
     return ( <>
         <CheckboxContainer>
-            <Input type="checkbox" id={id} name={name} value={value}/>
+            <Input type="checkbox" id={id} name={name} value={value} onChange={displayOtherTextareaInput}/>
             <Label for={id}>
                 {children}
             </Label>
         </CheckboxContainer>  
-        {id === 'other' && 
+        {id === 'other' && checked &&
                 <div className="other-text-input">
                     <Textarea placeholder={placeholder} name={name}></Textarea>
-
                 </div>
             }
   </>)


### PR DESCRIPTION
## Summary
Fixes issue #20 

## Details

### Why?
To keep the UI clean, hide the other textarea input and only display it when 'other' is checked.
### How?
In the Checkbox component, make a 'checked' state and set it to false boolean value by default. Make 'displayOtherTextareaInput' function to setChecked to the value of event.target.checked, which will be a boolean. Add onChange event listener to Input and reference 'displayOtherTextareaInput' function.
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
