### PR TITLE
make 'other' reusable checkbox wider

### DIFF
--- a/src/utils/Checkbox.jsx
+++ b/src/utils/Checkbox.jsx
@@ -18,9 +18,7 @@ function Checkbox({id, name, value, children, placeholder}) {
             </Label>
         </CheckboxContainer>  
         {id === 'other' && checked &&
-                <div className="other-text-input">
                     <Textarea placeholder={placeholder} name={name}></Textarea>
-                </div>
             }
   </>)
 }
@@ -38,7 +36,7 @@ const Input = styled.input`
   margin-right: 1rem;
   height: 1.1rem;
   width: 1.1rem;
-  accent-color: grey;
+  accent-color: grey; 
 `;
 
 const Label = styled.label`


### PR DESCRIPTION
## Summary
Fixes issue #22 

## Details

### Why?
The 'other' textarea input is too narrow and looks bad. 
### How?
Remove the container div from the Textarea imported component
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
