### PR TITLE
Add favorite websites component content and show all placeholder text

### DIFF
--- a/src/components/FavoriteWebsites.jsx
+++ b/src/components/FavoriteWebsites.jsx
@@ -1,9 +1,12 @@
-import React from 'react'
+import Question from "../utils/Question"
 
 function FavoriteWebsites() {
-  return (
-    <div>FavoriteWebsites</div>
-  )
+  return (<>
+    <Question>
+    What are your three favorite websites and what do you like about them? If you don’t have three favorite websites, find three that you like. Please provide links.
+    </Question>
+    
+  </>)
 }
 
 export default FavoriteWebsites

--- a/src/components/FavoriteWebsites.jsx
+++ b/src/components/FavoriteWebsites.jsx
@@ -1,11 +1,22 @@
 import Question from "../utils/Question"
+import Textarea from "../utils/Textarea"
 
 function FavoriteWebsites() {
   return (<>
     <Question>
     What are your three favorite websites and what do you like about them? If you don’t have three favorite websites, find three that you like. Please provide links.
     </Question>
-    
+    <Textarea id='favsites' placeholder='
+      websitelink1@example.com
+      like 1, like 2, like 3, ...
+
+      websitelink1@example.com
+      like 1, like 2, like 3, ...
+
+      websitelink1@example.com
+      like 1, like 2, like 3, ...
+    '></Textarea>
+
   </>)
 }
 

--- a/src/utils/Textarea.jsx
+++ b/src/utils/Textarea.jsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
-function Textarea({placeholder, name}) {
+function Textarea({placeholder, name, id}) {
   return (
-    <TextareaInput placeholder={placeholder} name={name}></TextareaInput>
+    <TextareaInput id={id} placeholder={placeholder} name={name}></TextareaInput>
   )
 }
 
@@ -10,6 +10,10 @@ function Textarea({placeholder, name}) {
 const TextareaInput = styled.textarea`
 width: 70%;
 height: 8rem;
+
+&#favsites {
+  height: 12rem;
+}
 padding: 1rem;
 border-radius: 20px;
 border: none;


### PR DESCRIPTION
## Summary
Fixes issue #35 

## Details

### Why?
Placeholder text is too long and is therefore cut off when textarea has default height.
### How?
In Textarea component, pass id props, then in the styled component, set unique height using the id as a selector.

## Additional Information

## Checks
- [x] Did you reference the issue? 
- [ ] Does this commit follow SRP? 
