### PR TITLE
Persist BackgroundInfo input data in local storage

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -20,8 +20,13 @@ import Submit from './Submit';
 
 
 function Form() {
+<<<<<<< Updated upstream
 
   const [page, setPage] = useState(0);
+=======
+  const [page, setPage] = useState(2);
+  const [isExploding, setIsExploding] = useState(false);
+>>>>>>> Stashed changes
   const FormTitles = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
 
   const handleIncrementClick = (e) => {
@@ -90,7 +95,14 @@ function Form() {
         <Body>{pageDisplay()}</Body>
         <ButtonContainer>
             { page > 0 && <PrevButton disabled={page === 0} type="button" onClick={handleDecrementClick}><i className="fa-solid fa-arrow-left-long"></i></PrevButton>}
+<<<<<<< Updated upstream
             <NextButton  disabled={page === FormTitles.length - 1} type="button" onClick={handleIncrementClick}>{page > 0 ? <p>Next</p> : <p>Let's go!</p>}<i className="fa-solid fa-arrow-right-long"></i></NextButton>
+=======
+            {page < FormTitles.length - 1 && <NextButton  disabled={page === FormTitles.length - 1} type="button" onClick={handleIncrementClick}>{page > 0 ? <p>Next</p> : <p>Let's go!</p>}<i className="fa-solid fa-arrow-right-long"></i></NextButton>}
+            <SubmitBtn type="submit" onClick={() => setIsExploding(!isExploding)}><p>Submit</p><i class="fa-solid fa-paper-plane"></i></SubmitBtn>
+            {/* {page === FormTitles.length - 1 && <SubmitBtn type="submit" onClick={() => setIsExploding(!isExploding)}><p>Submit</p><i class="fa-solid fa-paper-plane"></i></SubmitBtn>} */}
+            {isExploding && <ConfettiExplosion {...confettiProps}/>}
+>>>>>>> Stashed changes
         </ButtonContainer>
         </FormWrapperInner>
     </FormWrapperOuter>

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -120,7 +120,6 @@ function Form() {
             { page > 0 && <PrevButton disabled={page === 0} type="button" onClick={handleDecrementClick}><i className="fa-solid fa-arrow-left-long"></i></PrevButton>}
             {page < FormTitles.length - 1 && <NextButton  disabled={page === FormTitles.length - 1} type="button" onClick={handleIncrementClick}>{page > 0 ? <p>Next</p> : <p>Let's go!</p>}<i className="fa-solid fa-arrow-right-long"></i></NextButton>}
             <SubmitBtn type="submit" onClick={() => setIsExploding(!isExploding)}><p>Submit</p><i class="fa-solid fa-paper-plane"></i></SubmitBtn>
-            {/* {page === FormTitles.length - 1 && <SubmitBtn type="submit" onClick={() => setIsExploding(!isExploding)}><p>Submit</p><i class="fa-solid fa-paper-plane"></i></SubmitBtn>} */}
             {isExploding && <ConfettiExplosion {...confettiProps}/>}
         </ButtonContainer>
         </FormWrapperInner>
@@ -202,19 +201,7 @@ const NextButton = styled.button`
     align-items: center;
     cursor: pointer; 
     
-    @supports (background-clip: text) {
-      p {
-        background: linear-gradient( to right, #FDB456, #DD7A78, #BA3D9C);
-        background-clip: text;
-        color: transparent;
-      }
-      
-      i {
-        background: linear-gradient( to right, #FDB456, #DD7A78, #BA3D9C);
-        background-clip: text;
-        color: transparent;
-      }
-    }
+    
 
     p {
       color: #BA3D9C;
@@ -228,6 +215,20 @@ const NextButton = styled.button`
      i {
       color: #BA3D9C;
      }
+     
+     @supports (background-clip: text) {
+      p {
+        background: linear-gradient( to right, #FDB456, #DD7A78, #BA3D9C);
+        background-clip: text;
+        color: transparent;
+      }
+      
+      i {
+        background: linear-gradient( to right, #FDB456, #DD7A78, #BA3D9C);
+        background-clip: text;
+        color: transparent;
+      }
+    }
 `;
 
 const SubmitBtn = styled(NextButton)`

--- a/src/utils/RadioButton.jsx
+++ b/src/utils/RadioButton.jsx
@@ -1,11 +1,40 @@
 import styled from "styled-components"
+import { useRef } from "react";
 
 
 function RadioButton({id, value, name, children}) {
+  // const [radioState, setRadioState] = useState('');
+  const [radioState, setRadioState] = useState(localStorage.getItem(name) ?? '');
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    localStorage.setItem(name, JSON.stringify(radioState));
+    if (inputRef.current) {
+      inputRef.current.checked = radioState === value;
+    }
+  }, [radioState]);
+
+  useEffect(() => {
+    const storedValue = localStorage.getItem(name);
+    setRadioState(storedValue ?? value)
+  }, []);
+
+  const handleChange = (e) => {
+    const newValue = e.target.value;
+    setRadioState(newValue)
+  }
+ 
+
+console.log(inputRef)
+
   return (<>
     <SelectionContainer>
-        <Input type='radio'  id={id} value={value}  name={name}/>
-        <Label for={id}>
+        <Input 
+        ref={inputRef}
+        type='radio'  id={id} 
+        value={value}  name={name} 
+        onChange={(e) => handleChange(e)}/>
+        <Label htmlForfor={id}>
             {children}
         </Label>
     </SelectionContainer>


### PR DESCRIPTION


## Summary
Fixes issue #50 

## Details

### Why?
So users can review their answers before submitting and data can be sent via emailJS
### How?
- Set radioState equal to localStorage, or default to empty string. 
- Add useEffect to update localStorage every time radioState changes. 
- Add onChange/handleChange functions to update radioState every time user selects new answer.

## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
