### PR TITLE
Fix 'Other' textarea 

### DIFF
--- a/src/components/ContentType.jsx
+++ b/src/components/ContentType.jsx
@@ -1,6 +1,7 @@
 import Question from "../utils/Question"
 import Checkbox from "../utils/Checkbox"
 import { useState, useEffect } from "react";
+import styled from "styled-components";
 
 const allContentTypes = [
   { name: "Pictures", checked: false },
@@ -13,6 +14,7 @@ const allContentTypes = [
 
 function ContentType() {
   const [contentTypes, setContentTypes] = useState(JSON.parse(sessionStorage.getItem('contentTypes')) ?? allContentTypes);
+  const [otherTextArea, setOtherTextArea] = useState(JSON.parse(sessionStorage.getItem('user_otherContentTypes')) ?? '');
 
   const updateCheckStatus = index => {
     setContentTypes(
@@ -28,6 +30,14 @@ function ContentType() {
       sessionStorage.setItem('contentTypes', JSON.stringify(contentTypes))
   }, [contentTypes])
 
+  const handleOtherTextareaChange = (e) => {
+    setOtherTextArea(e.target.value);
+  };
+  
+  useEffect(() => {
+    sessionStorage.setItem('user_otherContentTypes', JSON.stringify(otherTextArea));
+  }, [otherTextArea])
+
 //  console.log(contentTypes)
 
   return (<>
@@ -42,8 +52,25 @@ function ContentType() {
           index={index}
         />
       ))}
-
+      {contentTypes[5].checked === true && 
+    <TextareaInput
+      placeholder='Please list all other content types.'
+      value={otherTextArea}
+      onChange={handleOtherTextareaChange}
+    ></TextareaInput>}
   </>)
 }
+
+const TextareaInput = styled.textarea`
+width: 70%;
+height: 8rem;
+padding: 1rem;
+border-radius: 20px;
+border: none;
+margin-top: 1.5rem;
+&:focus {
+  border: 2px solid gray;
+}
+`
 
 export default ContentType

--- a/src/components/WebsiteFeatures.jsx
+++ b/src/components/WebsiteFeatures.jsx
@@ -1,6 +1,8 @@
+import styled from 'styled-components';
 import Checkbox from '../utils/Checkbox'
 import Question from '../utils/Question'
 import { useState, useEffect } from "react";
+
 
 const allFeatures = [
   {name: 'Payment Portal', checked: false},
@@ -26,7 +28,8 @@ function WebsiteFeatures() {
     sessionStorage.setItem('websiteFeatures', JSON.stringify(websiteFeatures))
 }, [websiteFeatures])
 
-// console.log(websiteFeatures)
+// console.log(websiteFeatures[3].checked)
+
   return (<>
     <Question>What features do you need on your website? Select all that apply.</Question>
 
@@ -39,7 +42,21 @@ function WebsiteFeatures() {
         index={index}
       />
     ))}
+    {websiteFeatures[3].checked === true && <TextareaInput></TextareaInput>}
   </>)
 }
+
+
+const TextareaInput = styled.textarea`
+width: 70%;
+height: 8rem;
+padding: 1rem;
+border-radius: 20px;
+border: none;
+margin-top: 1.5rem;
+&:focus {
+  border: 2px solid gray;
+}
+`
 
 export default WebsiteFeatures

--- a/src/components/WebsiteFeatures.jsx
+++ b/src/components/WebsiteFeatures.jsx
@@ -13,6 +13,7 @@ const allFeatures = [
 
 function WebsiteFeatures() {
   const [websiteFeatures, setWebsiteFeatures] = useState(JSON.parse(sessionStorage.getItem('websiteFeatures')) ?? allFeatures);
+  const [otherTextArea, setOtherTextArea] = useState(JSON.parse(sessionStorage.getItem('user_otherWebsiteFeatures')) ?? '');
 
   const updateCheckStatus = index => {
     setWebsiteFeatures(
@@ -28,6 +29,14 @@ function WebsiteFeatures() {
     sessionStorage.setItem('websiteFeatures', JSON.stringify(websiteFeatures))
 }, [websiteFeatures])
 
+const handleOtherTextareaChange = (e) => {
+  setOtherTextArea(e.target.value);
+};
+
+useEffect(() => {
+  sessionStorage.setItem('user_otherWebsiteFeatures', JSON.stringify(otherTextArea));
+}, [otherTextArea])
+
 // console.log(websiteFeatures[3].checked)
 
   return (<>
@@ -42,7 +51,12 @@ function WebsiteFeatures() {
         index={index}
       />
     ))}
-    {websiteFeatures[3].checked === true && <TextareaInput></TextareaInput>}
+    {websiteFeatures[3].checked === true && 
+    <TextareaInput
+      placeholder='Please list all other features.'
+      value={otherTextArea}
+      onChange={handleOtherTextareaChange}
+    ></TextareaInput>}
   </>)
 }
 

--- a/src/utils/Checkbox.jsx
+++ b/src/utils/Checkbox.jsx
@@ -13,7 +13,7 @@ function Checkbox({ isChecked, label, checkHandler, index }) {
       />
       <Label htmlFor={`checkbox-${index}`}>{label}</Label>
         </CheckboxContainer>   
-        {label === 'Other' && isChecked ? <Textarea placeholder={'Please explain.'}/> : null}
+        {/* {label === 'Other' && isChecked ? <Textarea name={label} placeholder={'Please explain.'}/> : null} */}
   </>)
 }
 


### PR DESCRIPTION
## Summary
Fixes issue #62 

## Details

### Why?
So the data is seperate and can store different values.
### How?
Instead of using the reusable Textarea component, locally implement textarea input and make it a controlled input. 
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
