### PR TITLE
clear form data from sessionStorage on submit

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -50,6 +50,7 @@ function Form() {
       }, (error) => {
           console.log(error.text);
       });
+      sessionStorage.clear();
   };
 
   const handleIncrementClick = (e) => {


### PR DESCRIPTION
## Summary
Fixes issue #66 

## Details

### Why?
- To clear session storage and prevent user's device throwing QuotaExceededError.
- If they want to resubmit the form, they don't have to manually erase their previous answers.
### How?
At the bottom of the sendEmail function, call sessionStorage.clear();
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
