### PR TITLE
only show submit button on submit page

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -45,7 +45,6 @@ function Form() {
       form.current, 
       import.meta.env.VITE_EMAILJS_PUBLIC_KEY)
       .then((result) => {
-          console.log(form.current);
           console.log('message sent');
       }, (error) => {
           console.log(error.text);
@@ -118,7 +117,7 @@ function Form() {
         <ButtonContainer>
             { page > 0 && <PrevButton disabled={page === 0} type="button" onClick={handleDecrementClick}><i className="fa-solid fa-arrow-left-long"></i></PrevButton>}
             {page < FormTitles.length - 1 && <NextButton  disabled={page === FormTitles.length - 1} type="button" onClick={handleIncrementClick}>{page > 0 ? <p>Next</p> : <p>Let's go!</p>}<i className="fa-solid fa-arrow-right-long"></i></NextButton>}
-            <SubmitBtn type="submit" onClick={() => setIsExploding(!isExploding)}><p>Submit</p><i class="fa-solid fa-paper-plane"></i></SubmitBtn>
+            {page === FormTitles.length -1 && <SubmitBtn type="submit" onClick={() => setIsExploding(!isExploding)}><p>Submit</p><i class="fa-solid fa-paper-plane"></i></SubmitBtn>}
             {isExploding && <ConfettiExplosion {...confettiProps}/>}
         </ButtonContainer>
         </FormWrapperInner>


### PR DESCRIPTION
## Summary
Fixes issue n/a

## Details

### Why?
Users should only be able to submit the form after complete each page. All form data can only be collated and sent on submit page. 
### How?
Wrap submit button in condition checking if the current page is equal to the last page. When true, submit button will be shown.
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
