### PR TITLE
add name and value to Checkbox and to components that use Checkbox

### DIFF
--- a/src/components/ContentType.jsx
+++ b/src/components/ContentType.jsx
@@ -4,12 +4,12 @@ import { useState, useEffect } from "react";
 import styled from "styled-components";
 
 const allContentTypes = [
-  { name: "Pictures", checked: false },
-  { name: "Videos", checked: false },
-  { name: "Music files", checked: false },
-  { name: "Blog posts", checked: false },
-  { name: "Product listings", checked: false },
-  { name: "Other", checked: false },
+  { label: "Pictures", checked: false },
+  { label: "Videos", checked: false },
+  { label: "Music files", checked: false },
+  { label: "Blog posts", checked: false },
+  { label: "Product listings", checked: false },
+  { label: "Other", checked: false },
 ]
 
 function ContentType() {
@@ -45,17 +45,20 @@ function ContentType() {
     
     {contentTypes.map((contentType, index) => (
         <Checkbox
-          key={contentType.name}
+          key={contentType.label}
           isChecked={contentType.checked}
           checkHandler={() => updateCheckStatus(index)}
-          label={contentType.name}
+          label={contentType.label}
           index={index}
+          name={"user_contentTypes"}
+          value={contentType.label}
         />
       ))}
       {contentTypes[5].checked === true && 
     <TextareaInput
       placeholder='Please list all other content types.'
       value={otherTextArea}
+      name={"user_otherContentTypes"}
       onChange={handleOtherTextareaChange}
     ></TextareaInput>}
   </>)

--- a/src/components/WebsiteFeatures.jsx
+++ b/src/components/WebsiteFeatures.jsx
@@ -5,10 +5,10 @@ import { useState, useEffect } from "react";
 
 
 const allFeatures = [
-  {name: 'Payment Portal', checked: false},
-  {name: 'Appointment Scheduling', checked: false},
-  {name: 'Contact Form', checked: false},
-  {name: 'Other', checked: false},
+  {label: 'Payment Portal', checked: false},
+  {label: 'Appointment Scheduling', checked: false},
+  {label: 'Contact Form', checked: false},
+  {label: 'Other', checked: false},
 ];
 
 function WebsiteFeatures() {
@@ -44,17 +44,20 @@ useEffect(() => {
 
     {websiteFeatures.map((websiteFeature, index) => (
       <Checkbox
-        key={websiteFeature.name}
+        key={websiteFeature.label}
         isChecked={websiteFeature.checked}
         checkHandler={() => updateCheckStatus(index)}
-        label={websiteFeature.name}
+        label={websiteFeature.label}
         index={index}
+        value={websiteFeature.label}
+        name={"user_websiteFeatures"}
       />
     ))}
     {websiteFeatures[3].checked === true && 
     <TextareaInput
       placeholder='Please list all other features.'
       value={otherTextArea}
+      name={"user_otherWebsiteFeatures"}
       onChange={handleOtherTextareaChange}
     ></TextareaInput>}
   </>)

--- a/src/utils/Checkbox.jsx
+++ b/src/utils/Checkbox.jsx
@@ -2,7 +2,7 @@ import styled from "styled-components"
 import Textarea from "./Textarea";
 
 
-function Checkbox({ isChecked, label, checkHandler, index }) {
+function Checkbox({ isChecked, label, checkHandler, index, name, value }) {
     return ( <>
         <CheckboxContainer>
         <Input
@@ -10,6 +10,8 @@ function Checkbox({ isChecked, label, checkHandler, index }) {
         id={`checkbox-${index}`}
         checked={isChecked}
         onChange={checkHandler}
+        name={name}
+        value={value}
       />
       <Label htmlFor={`checkbox-${index}`}>{label}</Label>
         </CheckboxContainer>   


### PR DESCRIPTION


## Summary
Fixes issue #69 

## Details

### Why?
Name attribute is needed for emailJS to access the component's data and send data via email. Value of name attribute must match  corresponding emailJS email template variable name.
### How?
- Add dynamic name and value attributes to  Checkbox. 
- In WebsiteFeatures and ContentType, add name and value attributes to returned Checkbox and add name attribute to both component's TextareaInput which represents the 'other' option.
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
