### PR TITLE
Close tab button

### DIFF
--- a/src/components/Congratulation.jsx
+++ b/src/components/Congratulation.jsx
@@ -1,9 +1,15 @@
 import React from 'react'
 import styled from 'styled-components'
 
+const handleCloseTab = () => {
+    window.opener = null;
+    window.open("", "_self");
+    window.close();
+}
+
 function Congratulation() {
   return (<>
-    <Header>Congratulations!</Header>
+    <Header>Congratulations</Header>
     <SubHeader>You made it!</SubHeader>
     <CongratulationBodyText>
         All your answers have been saved and are on their way to our team now.
@@ -11,12 +17,17 @@ function Congratulation() {
     <CongratulationBodyText>
         You can safely close this tab and enjoy the rest of your day 😁
     </CongratulationBodyText>
+
+    <CloseTabBtn onClick={handleCloseTab}>Close Tab</CloseTabBtn>
+
   </>)
 }
 
 const Header = styled.h1`
   color: white;
   font-size: 2rem;
+  padding-bottom: .5rem;
+  border-bottom: 3px solid white;
 `;
 
 const SubHeader = styled.h2`
@@ -29,6 +40,10 @@ const CongratulationBodyText = styled.p`
   text-align: center;
   width: 83%;
   line-height: 1.5rem;
+`;
+
+const CloseTabBtn = styled.button`
+    
 `;
 
 export default Congratulation

--- a/src/components/Congratulation.jsx
+++ b/src/components/Congratulation.jsx
@@ -4,27 +4,31 @@ import styled from 'styled-components'
 function Congratulation() {
   return (<>
     <Header>Congratulations!</Header>
-    <subHeader>You made it!</subHeader>
-    <congratulationBodyText>
+    <SubHeader>You made it!</SubHeader>
+    <CongratulationBodyText>
         All your answers have been saved and are on their way to our team now.
-    </congratulationBodyText>
-    <congratulationBodyText>
+    </CongratulationBodyText>
+    <CongratulationBodyText>
         You can safely close this tab and enjoy the rest of your day 😁
-    </congratulationBodyText>
-
+    </CongratulationBodyText>
   </>)
 }
 
 const Header = styled.h1`
   color: white;
+  font-size: 2rem;
 `;
 
-const subHeader = styled.h2`
+const SubHeader = styled.h2`
   color: white;
+  font-size: 2rem;
 `;
 
-const congratulationBodyText = styled.p`
+const CongratulationBodyText = styled.p`
   color: white;
+  text-align: center;
+  width: 83%;
+  line-height: 1.5rem;
 `;
 
 export default Congratulation

--- a/src/components/Congratulation.jsx
+++ b/src/components/Congratulation.jsx
@@ -1,11 +1,14 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import styled from 'styled-components'
 
 const handleCloseTab = () => {
-    window.opener = null;
-    window.open("", "_self");
     window.close();
 }
+
+useEffect(() => {
+    window.open("https://client-ui-design-questionairre.netlify.app/", "_self", "");
+    console.log("open window");
+    }, []);
 
 function Congratulation() {
   return (<>

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -25,7 +25,7 @@ import ConfettiExplosion from 'react-confetti-explosion';
 
 
 function Form() {
-  const [page, setPage] = useState(0);
+  const [page, setPage] = useState(14);
   const [isExploding, setIsExploding] = useState(false);
   const FormTitles = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
   const form = useRef();


### PR DESCRIPTION
## Summary
Fixes issue #73 

## Details

### Why?
So users can easily exit the form.
### How?
- Add useEffect to call window.open to open new tab in same view in order to be able to call window.close() in handleCloseTab
- on CloseTabBtn styled component, add click event and pass to it a reference to handleCloseTab function
- In handleCloseTab function, call window.close();
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
