### PR TITLE
Increase text content size

### DIFF
--- a/src/components/Welcome.jsx
+++ b/src/components/Welcome.jsx
@@ -26,16 +26,17 @@ const HeaderMessage = styled.h1`
     color: #BA3D9C;
     text-transform: uppercase;
     font-family: 'Krona One', sans-serif;
-    font-size: 2rem;
+    font-size: 6rem;
     letter-spacing: .5rem;
-    margin-top: -15vw;
+    /* margin-top: 0vw; */
 `;
 
 const BodyText = styled.p`
   color: white;
   text-align: center;
   width: 80%;
-  line-height: 1.5rem;
+  line-height: 5rem;
+  font-size: 3rem;
 `;
  
 export default Welcome


### PR DESCRIPTION
## Summary
Fixes issue #79 

## Details

### Why?
- text and button was too small on Chrome browser. 
### How?

## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
