### PR TITLE
increase progress bar height

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -166,7 +166,7 @@ const FormWrapperOuter  = styled.form`
 
 const ProgressBarContainer = styled.div`
     background-color: white;
-    height: 10px;
+    height: 25px;
     width: 100vw;
     position: absolute;
     top: 0;


### PR DESCRIPTION
## Summary
Fixes issue #82 

## Details

### Why?
- Progress bar is too narrow  and is hard to see.
### How?

## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
