### PR TITLE
set placeholder font size to 20px

### DIFF
--- a/src/components/ContentType.jsx
+++ b/src/components/ContentType.jsx
@@ -74,7 +74,8 @@ margin-top: -4rem;
 margin-bottom: 3rem;
 
 &::placeholder {
-  font-size: 1.5rem;
+  /* font-size: 1.5rem; */
+  font-size: 20px;
 }
 &:focus {
   border: 2px solid gray;


### PR DESCRIPTION
## Summary
Fixes issue #98 

## Details

### Why?

### How?
- Increase ContentType's placeholder text size to 20px to try and prevent mobile browser automatic zooming behavior 
## Additional Information

## Checks
- [ ] Did you reference the issue? 
- [ ] Does this commit follow SRP? 
