### PR TITLE
increase WebsiteFeatures 'other' textarea placeholder text size and height

### DIFF
--- a/src/components/WebsiteFeatures.jsx
+++ b/src/components/WebsiteFeatures.jsx
@@ -64,14 +64,14 @@ useEffect(() => {
 
 const TextareaInput = styled.textarea`
 width: 80%;
-height: 8rem;
+height: 14rem;
 padding: 1rem;
 border-radius: 20px;
 margin-top: -4rem;
 margin-bottom: 3rem;
 
 &::placeholder {
-  font-size: 1.5rem;
+  font-size: 2.1rem;
 }
 
 &:focus {


### PR DESCRIPTION
## Summary
Fixes issue #97 

## Details

### Why?

### How?
- Increase WebsiteFeatures 'other' textarea placeholder text size and height
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
