### PR TITLE
reduce CheckboxContainer height

### DIFF
--- a/src/utils/Checkbox.jsx
+++ b/src/utils/Checkbox.jsx
@@ -24,7 +24,7 @@ display: flex;
 align-items: center;
 justify-content: flex-start;
 width: 80%;
-height: 6rem;
+height: 3rem;
 margin-bottom: 6rem;
 `;
 


### PR DESCRIPTION
## Summary
Fixes issue #101 

## Details

### Why?
- When 'other' textarea input is open, the checkboxes are pushed up and overlap with the prevButton.
### How?
- In Checkbox, reduce CheckboxContainer height
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
