### PR TITLE
increase PersonalInforContainer margin bottom

### DIFF
--- a/src/components/PersonalInfo.jsx
+++ b/src/components/PersonalInfo.jsx
@@ -79,7 +79,7 @@ const PersonalInfoContainer = styled.div`
   flex-direction: column;
   justify-content: space-between;
   height: 40vh;
-  margin-bottom: 3rem;
+  margin-bottom: 7rem;
 `;
 
 const InputContainer = styled.div`


### PR DESCRIPTION
## Summary
Fixes issue #86 

## Details

### Why?
- NextButton is too close to bottom input and UI looks crowded
### How?

## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
