### PR TITLE
increase submit page text font size

### DIFF
--- a/src/utils/Question.jsx
+++ b/src/utils/Question.jsx
@@ -18,7 +18,6 @@ const QuestionText = styled.p`
   }
 
   &#submit-message {
-    font-size: 1.3rem;
     padding-bottom: 1rem;
   }
 `;


### PR DESCRIPTION
## Summary
Fixes issue #110 

## Details

### Why?

### How?
- In Question, remove font size rule from #submit-message selector so that it uses the default font size of the styled component instead.
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
