### PR TITLE
fix progress bar width to stop it overflowing on submit and congratulations pages

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -119,7 +119,7 @@ function Form() {
   return (
     <FormWrapperOuter ref={form} onSubmit={sendEmail}>
         <ProgressBarContainer>
-          <ProgressBar style={{width: `${page * 8}%`}}></ProgressBar>
+          <ProgressBar style={{width: `${page * 7.14}%`}}></ProgressBar>
         </ProgressBarContainer>
         <FormWrapperInner>
         <Body>{pageDisplay()}</Body>


### PR DESCRIPTION

## Summary
Fixes issue #116 

## Details

### Why?

### How?
- In Form, adjust the calculation by which the width of the progress bar is calculated from (page * 8) to (page * 7.14) 
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
