### PR TITLE
in PersonalInfo fix useState syntax to default to empty string if sessionStorage unavailable

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -146,7 +146,7 @@ function Form() {
               type="submit" 
               onClick={handleSubmit}>
               <p>Submit</p>
-              <i class="fa-solid fa-paper-plane"></i>
+              <i className="fa-solid fa-paper-plane"></i>
             </SubmitBtn>}
             {isExploding && <ConfettiExplosion {...confettiProps}/>}
         </ButtonContainer>

--- a/src/components/PersonalInfo.jsx
+++ b/src/components/PersonalInfo.jsx
@@ -3,10 +3,10 @@ import styled from 'styled-components'
 import { useState, useEffect } from 'react';
 
 function PersonalInfo() {
-const [firstAndLastName, setfirstAndLastName] = useState(JSON.parse(sessionStorage.getItem('FirstAndLastName' ?? '')));
-const [email, setEmail] = useState(JSON.parse(sessionStorage.getItem('email' ?? '')));
-const [companyName, setCompanyName] = useState(JSON.parse(sessionStorage.getItem('companyName' ?? '')));
-const [companyIndustry, setCompanyIndustry] = useState(JSON.parse(sessionStorage.getItem('companyIndustry' ?? '')));
+const [firstAndLastName, setfirstAndLastName] = useState(JSON.parse(sessionStorage.getItem('FirstAndLastName')) ?? '');
+const [email, setEmail] = useState(JSON.parse(sessionStorage.getItem('email')) ?? '');
+const [companyName, setCompanyName] = useState(JSON.parse(sessionStorage.getItem('companyName')) ?? '');
+const [companyIndustry, setCompanyIndustry] = useState(JSON.parse(sessionStorage.getItem('companyIndustry')) ?? '');
 
 const handleNameChange = (e) => {
   sessionStorage.setItem('FirstAndLastName', JSON.stringify(e.target.value));


### PR DESCRIPTION


## Summary
Fixes issue #118 

## Details

### Why?
- Chrome dev tools throwing error that inputs were evaluating to null.
### How?
- Fix useState syntax so that if sessionStorage is empty, states will default to empty strings
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
