### PR TITLE
move DesignPreferences content closer to top of viewport

### DIFF
--- a/src/components/DesignPreferences.jsx
+++ b/src/components/DesignPreferences.jsx
@@ -15,7 +15,7 @@ function DesignPreferences() {
   }, [designPreferences]);
   
   return (<>
-    <Question>Do you have any specific design preferences that should be followed?</Question>
+    <Question className={'design-preferences'}>Do you have any specific design preferences that should be followed?</Question>
 
     <SelectionContainer>
       <Input

--- a/src/utils/Question.jsx
+++ b/src/utils/Question.jsx
@@ -12,9 +12,15 @@ const QuestionText = styled.p`
   border-bottom: 4px solid white;
   width: 80%;
   font-size: 2.5rem;
+  /* margin-top: -5rem; */
 
   &:not(:first-child){
     margin-top: 7rem;
+  }
+
+  &.design-preferences {
+    margin-top: -15rem;
+    margin-bottom: 3rem;
   }
 
   &.unique-qualities, &.target-demographic {


### PR DESCRIPTION
## Summary
Fixes issue #123 

## Details

### Why?

### How?
- Add classname to DesignPreferences Question element. 
- In Question, add styling rule for DesignPreferences className.
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
