### PR TITLE
increas NextButton margin top

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -220,7 +220,7 @@ const NextButton = styled.button`
     padding: 0 5rem;
     border-radius: 70px;
     font-size: 2.4rem;
-    margin-top: 3rem;
+    margin-top: 5rem;
     display: flex;
     align-items: center;
     cursor: pointer; 


### PR DESCRIPTION
## Summary
Fixes issue #123 

## Details

### Why?
- NextButton is too close to input content
### How?
- Increase margin top
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
