### PR TITLE
move unique qualities and target demographic content closer to top of viewport

### DIFF
--- a/src/utils/Question.jsx
+++ b/src/utils/Question.jsx
@@ -43,8 +43,9 @@ const QuestionText = styled.p`
     margin-bottom: 3rem;
   }
 
-  
   &.unique-qualities, &.target-demographic {
+    margin-top: -15rem;
+    margin-bottom: 3rem;
     width: 100%;
   }
 


### PR DESCRIPTION

## Summary
Fixes issue  #132  

## Details

### Why?

### How?
- Add style rules for `unique qualities` and `target-demographic` classNames
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
