### PR TITLE
increase space between inputs and move content up towards top of viewport

### DIFF
--- a/src/components/PersonalInfo.jsx
+++ b/src/components/PersonalInfo.jsx
@@ -78,8 +78,9 @@ const PersonalInfoContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 40vh;
+  height: 45vh;
   margin-bottom: 7rem;
+  margin-top: -5rem;
 `;
 
 const InputContainer = styled.div`


### PR DESCRIPTION


## Summary
Fixes issue #143 

## Details

### Why?

### How?
- Increase PersonalInfor height to add space between inputs and add negative top margin to move all content closer to top of viewport
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
