### PR TITLE
move 'let's go' button closer to bottom of body text

### DIFF
--- a/src/components/Welcome.jsx
+++ b/src/components/Welcome.jsx
@@ -39,6 +39,10 @@ const BodyText = styled.p`
   line-height: 5rem;
   font-size: 2.5rem;
   margin-bottom: 6rem;
+
+  &:nth-of-type(3) {
+    margin-bottom: 4rem;
+  }
 `;
  
 export default Welcome


### PR DESCRIPTION
## Summary
Fixes issue #130 

## Details

### Why?

### How?
- Select bottom paragraph using `:nth-of-type` pseudo-selector
- Reduce bottom margin 
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
