### PR TITLE
add margin top to content type question

### DIFF
--- a/src/components/ContentType.jsx
+++ b/src/components/ContentType.jsx
@@ -41,7 +41,7 @@ function ContentType() {
 //  console.log(contentTypes)
 
   return (<>
-    <Question>What kind of content do you plan to publish on your website? Select all that apply. </Question>
+    <Question className={'content-type'}>What kind of content do you plan to publish on your website? Select all that apply. </Question>
     
     {contentTypes.map((contentType, index) => (
         <Checkbox

--- a/src/utils/Question.jsx
+++ b/src/utils/Question.jsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import {devices} from '../utils/breakpoints';
 
 export default function Question({children, id, className}) {
   return (
@@ -36,6 +37,12 @@ const QuestionText = styled.p`
   &.website-goals {
     margin-top: -15rem;
     margin-bottom: 3rem;
+  }
+
+  &.content-type {
+    @media ${devices.mobileM} {
+      margin-top: 10rem;
+    }
   }
  
   &.website-features {


### PR DESCRIPTION
## Summary
Fixes issue
#148 
## Details

### Why?
- ContentType content is too close to the top of the viewport
### How?
- Add `.content-type` className to `<Question/>` component rendered in `contentType`.
- In `Question` add margin top style rule for `content-type` className in `mobileM` media query.
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
