### PR TITLE
increase congratulations margin top

### DIFF
--- a/src/components/Congratulation.jsx
+++ b/src/components/Congratulation.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 import styled from 'styled-components'
+import { devices } from "../utils/breakpoints"
 
 function Congratulation() {
   return (<>
@@ -23,6 +24,10 @@ const Header = styled.h1`
   padding-bottom: .5rem;
   border-bottom: 3px solid white;
   margin-top: -13rem;
+
+  @media ${devices.mobileM} {
+    margin-top: 4rem;
+  }
 `;
 
 const SubHeader = styled.h2`

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -19,7 +19,7 @@ import emailjs, { sendForm } from '@emailjs/browser';
 import ConfettiExplosion from 'react-confetti-explosion';
 
 function Form() {
-  const [page, setPage] = useState(0);
+  const [page, setPage] = useState(14);
   const [isExploding, setIsExploding] = useState(false);
 
   const [firstAndLastName, setfirstAndLastName] = useState(JSON.parse(sessionStorage.getItem('FirstAndLastName')) ?? '');


### PR DESCRIPTION
## Summary
Fixes issue #148 

## Details

### Why?
- Content is too close to top of viewport
### How?
- In mobileM media query, increase margin top from -13rem to 4rem
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
