### PR TITLE
add viewport meta tag in head of HTML to fix Chrome media queries bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Montserrat:wght@300;400;500;600&display=swap" rel="stylesheet"> 

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -228,6 +228,11 @@ const PrevButton = styled.button`
         color: transparent;
       }
     }
+
+    @media ${devices.mobileL} {
+      font-size: 2.3rem;
+      padding: 1rem 1.3rem;
+  }
 `;
 
 const NextButton = styled.button`
@@ -270,10 +275,11 @@ const NextButton = styled.button`
 
   @media ${devices.mobileL} {
     font-size: 2rem;
+    /* font-size: 5rem; */
   }
 
   @media ${devices.tablet} {
-    font-size: 1.5rem;
+    /* font-size: 1.5rem; */
   }
 `;
 

--- a/src/components/PersonalInfo.jsx
+++ b/src/components/PersonalInfo.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
 import { useState, useEffect } from 'react';
+import { devices } from '../utils/breakpoints';
+
 
 function PersonalInfo({firstAndLastName, setfirstAndLastName, email, setEmail, companyName, setCompanyName, companyIndustry, setCompanyIndustry}) {
 // const [firstAndLastName, setfirstAndLastName] = useState(JSON.parse(sessionStorage.getItem('FirstAndLastName')) ?? '');
@@ -89,6 +91,11 @@ const PersonalInfoContainer = styled.div`
   height: 45vh;
   margin-bottom: 7rem;
   margin-top: -5rem;
+
+  @media ${devices.mobileL} {
+    height: 50vh;
+    margin-top: 5rem;
+  }
 `;
 
 const InputContainer = styled.div`
@@ -106,6 +113,10 @@ const Label = styled.span`
   color: #e6e5e5;
   pointer-events: none;
   transition: 0.6s;
+
+  @media ${devices.mobileL} {
+    font-size: 2rem;
+  }
 `;
 
 const Input = styled.input`
@@ -132,6 +143,8 @@ const Input = styled.input`
     transform: translateY(-40px);
     font-size: 1.5rem;
    } 
+
+
 `;
 
 export default PersonalInfo

--- a/src/components/Welcome.jsx
+++ b/src/components/Welcome.jsx
@@ -33,18 +33,21 @@ const HeaderMessage = styled.h1`
   margin-bottom: 5rem;
   @media ${devices.mobileM} {
     margin-top: 0;
-  }
+    color: turquoise;
+  };
   
   @media ${devices.mobileL} {
+    color: blue;
     font-size: 5rem;
     margin-top: 1rem;
     margin-bottom: 2rem;
-  }
+  };
 
-  @media ${devices.tablet} {
+  @media ${devices.tablet}{
+    color: green;
     font-size: 4rem;
     margin-top: 1rem;
-  }
+  };
 `;
 
 const BodyText = styled.p`


### PR DESCRIPTION
## Summary
Fixes issue #159 

## Details

### Why?
- Media queries are being ignored by Chrome, but are being applied as expected in Firefox.
### How?
- Add viewport meta tag into head of HTML file ` <meta name="viewport" content="width=device-width,initial-scale=1">`
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
