### PR TITLE
adjust ContentType font size and element spacing

### DIFF
--- a/src/components/ContentType.jsx
+++ b/src/components/ContentType.jsx
@@ -66,15 +66,14 @@ function ContentType() {
 
 const TextareaInput = styled.textarea`
 width: 80%;
-height: 14rem;
+height: 9rem;
 padding: 1rem;
 border-radius: 20px;
 border: none;
-margin-top: -4rem;
-margin-bottom: 3rem;
+margin-top: 1rem;
 
 &::placeholder {
-  font-size: 2.1rem;
+  font-size: 0.8rem;
 }
 &:focus {
   border: 2px solid gray;

--- a/src/utils/Checkbox.jsx
+++ b/src/utils/Checkbox.jsx
@@ -25,19 +25,18 @@ align-items: center;
 justify-content: flex-start;
 width: 80%;
 height: 3rem;
-margin-bottom: 6rem;
 `;
 
 const Input = styled.input`
   margin-right: 1.5rem;
-  height: 1.9rem;
-  width: 1.9rem;
+  height: 1rem;
+  width: 1rem;
   accent-color: grey; 
 `;
 
 const Label = styled.label`
   color: white;
-  font-size: 2.2rem;
+  font-size: 0.9rem;
 `;
 
 export default Checkbox


### PR DESCRIPTION
## Summary
Fixes issue: #160 

### How?
- Reduce ContentType font size to .9rem.
- Increase ContentType other textarea top margin.
## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
