### PR TITLE
adjust UniqueQualities and TargetDemographic element spacing. Reduce progress bar height

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -178,7 +178,7 @@ const FormWrapperOuter  = styled.form`
 
 const ProgressBarContainer = styled.div`
     background-color: white;
-    height: 15px;
+    height: 10px;
     width: 100vw;
     position: absolute;
     top: 0;

--- a/src/utils/Question.jsx
+++ b/src/utils/Question.jsx
@@ -50,8 +50,7 @@ const QuestionText = styled.p`
   }
 
   &.unique-qualities, &.target-demographic {
-    margin-top: -15rem;
-    margin-bottom: 3rem;
+    margin-top: 2rem;
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary
Fixes issue: #160 

### How?
- Reduce progress bar height to 10px.
- In Question, for UniqueQualities and TargetDemographic, remove margin bottom and increase top margin to 2rem.
## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
