### PR TITLE
adjust BrandPersonality element spacing

### DIFF
--- a/src/utils/Question.jsx
+++ b/src/utils/Question.jsx
@@ -55,8 +55,7 @@ const QuestionText = styled.p`
   }
 
   &.brand-personality {
-    margin-top: -15rem;
-    margin-bottom: 3rem;
+    margin-top: 5rem;
   }
 
   &.favorite-websites {


### PR DESCRIPTION
## Summary
Fixes issue: #160

### How?
- In Questions, for BrandPersonality, remove margin bottom and increase margin top to 5rem.
## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
