### PR TITLE
adjust FavoriteWebsites element spacing

### DIFF
--- a/src/utils/Question.jsx
+++ b/src/utils/Question.jsx
@@ -59,8 +59,7 @@ const QuestionText = styled.p`
   }
 
   &.favorite-websites {
-    margin-top: -15rem;
-    margin-bottom: 3rem;
+    margin-top: 5rem;
   }
 
   &#submit-message {


### PR DESCRIPTION
## Summary
Fixes issue: #160

### How?
- In Question, for FavoriteWebsites, remove bottom margin and increase top margin to 5rem.
## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
